### PR TITLE
README: Update docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ These crates are similar but distinct by design:
 Documentation
 -------------
 
-[Read the documentation](https://docs.rs/double-checked-cell)
+[Read the documentation](https://docs.rs/double-checked-cell-async)
 
 Changelog
 ---------


### PR DESCRIPTION
The docs link points to `double-checked-cell` crate docs.